### PR TITLE
Add batch printing

### DIFF
--- a/badge_printing/models.py
+++ b/badge_printing/models.py
@@ -21,3 +21,21 @@ class Attendee:
     @cost_property
     def reprint_cost(self):
         return c.BADGE_REPRINT_FEE
+
+@Session.model_mixin
+class SessionMixin:
+    def filter_badges_for_printing(self, badge_list, **params):
+        """
+        Allows batch printing by grouping badges via the passed-in parameters.
+
+        :return:
+        """
+
+        if 'badge_type' in params:
+            return badge_list.filter(Attendee.badge_type == params['badge_type'])
+        elif 'dealer_only' in params:
+            return badge_list.filter(Attendee.ribbon.in_([c.DEALER_RIBBON, c.DEALER_ASST_RIBBON]))
+        elif 'badge_upgrade' in params:
+            return badge_list.filter(Attendee.amount_extra == params['badge_upgrade'])
+        else:
+            return badge_list

--- a/badge_printing/templates/kiosk_printing/index.html
+++ b/badge_printing/templates/kiosk_printing/index.html
@@ -12,6 +12,33 @@
     {% else %}<br/><a href="index?pending=True">Click here</a> to view the badges waiting to be printed.{% endif %}
 </div>
 
+<div style="text-align:center">
+    <form method="post" action="print_badges">
+        Badge type: <select name="badge_type">
+            {% options c.BADGE_OPTS c.ATTENDEE_BADGE %}
+        </select>
+        Minor? <input type="checkbox" name="minor" />
+        <input type="hidden" name="batch_printing" value=True />
+        <input type="submit" value="Print Badges By Type" />
+    </form>
+<br/>
+    <form method="post" action="print_badges">
+        Badge upgrade: <select name="badge_upgrade">
+            {% options c.DONATION_TIER_OPTS 0 %}
+        </select>
+        Minor? <input type="checkbox" name="minor" />
+        <input type="hidden" name="batch_printing" value=True />
+        <input type="submit" value="Print Badges By Upgrade" />
+    </form>
+<br/>
+    <form method="post" action="print_badges">
+        <input type="hidden" name="dealer_only" value="1"/>
+        Minor? <input type="checkbox" name="minor" />
+        <input type="hidden" name="batch_printing" value=True />
+        <input type="submit" value="Print Dealer Badges" />
+    </form>
+</div>
+
 <br/>
 <div class="panel panel-default">
     {% for pagenum in pages %}
@@ -22,7 +49,7 @@
         {% endif %}
     {% endfor %}
 {% if page %}
-<table class="table footable" data-page-size="9999999">
+<table class="table table-striped">
 <thead><tr>
     <th>Legal Name</th>
     <th>Badge Type</th>
@@ -43,14 +70,10 @@
             {{ attendee.badge_printed_name }}
         </td>
         <td id="amount_extra_{{ attendee.id }}">
-            {% if attendee.donation_tier != NO_DONATION %}
-                {{ attendee.donation_tier_label }} (Comped) <br/>
-            {% else %}
-                {{ attendee.amount_extra_label }}
-            {% endif %}
+            {{ attendee.amount_extra_label }}
         </td>
         <td id="ribbon_{{ attendee.id }}">{{ attendee.ribbon_label }}</td>
-        {% if not pending %}<form method="post" action="printed_badges">
+        {% if not pending %}<form method="post" action="index">
         <td>
             <input type="hidden" name="id" value="{{ attendee.id }}" />
             <input type="text" name="reprint_reason" placeholder="Reason for free reprint" />

--- a/badge_printing/templates/kiosk_printing/print_badges.html
+++ b/badge_printing/templates/kiosk_printing/print_badges.html
@@ -5,7 +5,9 @@
         window.print();
 
         // reload to print the next badge
-        setTimeout(function() {window.location = "print_badges?minor={{ minor }}";}, 9000);
+        setTimeout(function() {
+            document.getElementById("next_badge").submit();
+        }, 9000);
     </script>
     <!-- force chrome style for now -->
     <style type="text/css">
@@ -48,8 +50,16 @@ body {margin: 0; padding: 0;}
 <body>
     <div id="container">
         <span id="badge_type">{{ badge_type|safe }}</span>
-        <span id="badge_num">2015-{{ badge_num|stringformat:"04d" }}</span>
+        <span id="badge_num">2016-{{ badge_num|stringformat:"04d" }}</span>
         <span id="badge_name">{{ badge_name }}</span>
     </div>
+
+<form method="post" id="next_badge" action="print_badges" display="none">
+    <input type="hidden" name="minor" value="{{ minor }}"/>
+    {% for param in params.items %}
+        <input type="hidden" name="{{ param.0 }}" value="{{ param.1 }}"/>
+    {% endfor %}
+</form>
+
 </body>
 </html>


### PR DESCRIPTION
Many events (including, in this case, AnthroCon) will want to pre-print badges in batches. This lets admins print badges by type, upgrade, or Dealer status
